### PR TITLE
Helpers::editorLink: line is optional

### DIFF
--- a/src/Diagnostics/Helpers.php
+++ b/src/Diagnostics/Helpers.php
@@ -19,9 +19,11 @@ class Helpers extends Tracy\Helpers
 
 	/**
 	 * Returns link to editor.
+	 * @param string $file
+	 * @param int|null $line
 	 * @return Nette\Utils\Html
 	 */
-	public static function editorLink($file, $line)
+	public static function editorLink($file, $line = NULL)
 	{
 		if (Debugger::$editor && is_file($file)) {
 			$dir = dirname(strtr($file, '/', DIRECTORY_SEPARATOR));


### PR DESCRIPTION
Tracy\Helpers editorLink was changed in nette/tracy/commit/f88b73dd41afa5c7925b9f5797462154f982c0b9
